### PR TITLE
Pack: new pathFilter parameter

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -144,8 +144,8 @@ Pack.prototype._process = function () {
 
   if (me._noProprietary) wprops.noProprietary = true
 
-  // don't mess up with path if a filter is provided lest we confuse user.
-  wprops.path = me._pathFilter ? me._pathFilter( entry.path)
+  // don't mess with path when a filter is provided lest user may be confused.
+  wprops.path = me._pathFilter ? me._pathFilter(entry.path)
 	          :                  path.relative(root, entry.path || '')
 
   // actually not a matter of opinion or taste.

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -20,7 +20,11 @@ function Pack (props) {
   var me = this
   if (!(me instanceof Pack)) return new Pack(props)
 
-  if (props) me._noProprietary = props.noProprietary
+  if (props) {
+	  me._noProprietary = props.noProprietary || false
+	  me._pathFilter = props.pathFilter
+	  delete props.pathFilter;
+  }
   else me._noProprietary = false
 
   me._global = props
@@ -140,7 +144,9 @@ Pack.prototype._process = function () {
 
   if (me._noProprietary) wprops.noProprietary = true
 
-  wprops.path = path.relative(root, entry.path || '')
+  // don't mess up with path if a filter is provided lest we confuse user.
+  wprops.path = me._pathFilter ? me._pathFilter( entry.path)
+	          :                  path.relative(root, entry.path || '')
 
   // actually not a matter of opinion or taste.
   if (process.platform === "win32") {


### PR DESCRIPTION
This pathFilter parameter is necessary to create package for Debian or OpenEmbedded:
the tar files inside dpkg or ipkg package must have path like "./usr/bin/foo",
i.e. with a leading './'.

pathFilter expects a function which is run on each file or directory stored
in the archive. This takes path as a parameter and is expected to return
a modified path. For instance:

``` javascript
tar.Pack({
        noProprietary: true,
        pathFilter: function(p) {return './' + p ;}
    })
```
