### PR TITLE
Allow client to indicate tar root directory to be directory itself

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -131,7 +131,12 @@ Pack.prototype._process = function () {
   // in the tarball to use.  That way we can skip a lot of extra
   // work when resolving symlinks for bundled dependencies in npm.
 
-  var root = path.dirname((entry.root || entry).path)
+  var root = path.dirname((entry.root || entry).path);
+  if (me._global && me._global.fromBase && entry.root && entry.root.path) {
+    // user set 'fromBase: true' indicating tar root should be directory itself
+    root = entry.root.path;
+  }
+
   var wprops = {}
 
   Object.keys(entry.props || {}).forEach(function (k) {


### PR DESCRIPTION
I'm happy to make changes and update this request.

Currently if you tar '/a/to/path', the tarball has 'path' at its root, and when untarr'd, you'll get the 'path' directory

With fromBase set, the root will be '.', so when you untar the file, the files will be extracted to the current dir.