### PR TITLE
Pack root path fix

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -131,7 +131,12 @@ Pack.prototype._process = function () {
   // in the tarball to use.  That way we can skip a lot of extra
   // work when resolving symlinks for bundled dependencies in npm.
 
-  var root = path.dirname((entry.root || entry).path)
+	//console.log(">>>>>> entry.path\n\t",entry.root.path,"\n\t",entry.path);
+	
+ // var root = path.dirname((entry.root || entry).path)
+  var root = entry.root.path;
+  
+  //console.log("\t",root);
   var wprops = {}
 
   Object.keys(entry.props || {}).forEach(function (k) {
@@ -141,7 +146,6 @@ Pack.prototype._process = function () {
   if (me._noProprietary) wprops.noProprietary = true
 
   wprops.path = path.relative(root, entry.path || '')
-
   // actually not a matter of opinion or taste.
   if (process.platform === "win32") {
     wprops.path = wprops.path.replace(/\\/g, "/")


### PR DESCRIPTION
The archive doesn't include the current directory, only its content.

When I archive the directory '/test', I only want its content in the archive, not a new directory '/test'.
