### PR TITLE
Change log level on 'end' event

### DIFF
--- a/examples/extracter.js
+++ b/examples/extracter.js
@@ -7,5 +7,5 @@ fs.createReadStream(__dirname + "/../test/fixtures/c.tar")
     console.error("error here")
   })
   .on("end", function () {
-    console.error("done")
+    console.log("done")
   })


### PR DESCRIPTION
Ending the stream is not an error. `console.err` outputs an error message. `console.log` is for general output of logging information.
