### PR TITLE
make Extract propagate errors from its fstream writer

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -28,10 +28,13 @@ function Extract (opts) {
   opts.strip = +opts.strip
   if (!opts.strip || opts.strip <= 0) opts.strip = 0
 
-  this._fst = fstream.Writer(opts)
-
   this.pause()
   var me = this
+
+  this._fst = fstream.Writer(opts)
+  this._fst.on("error", function(err) {
+    me.emit("error", err);
+  }
 
   // Hardlinks in tarballs are relative to the root
   // of the tarball.  So, they need to be resolved against


### PR DESCRIPTION
Extract contains an fstream Writer but never listens for error events, so the creator of the Extract object cannot catch those errors without reaching into _fst which seems like a bad idea..  this change just propagates those errors so the caller can listen for errors on extract.

I would add a unit test but I'm unsure how to reliably create an error from the Writer (I ran across this with ENOSPC which isn't easy to re-create on demand)
