### PR TITLE
extract: propagate fstream `drain` event

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -61,6 +61,10 @@ function Extract (opts) {
     me.emit('error', err)
   })
 
+  this._fst.on('drain', function() {
+    me.emit('drain')
+  })
+
   // this._fst.on("end", function () {
   //   console.error("\nEEEE Extract End", me._fst.path)
   // })


### PR DESCRIPTION
I'm pretty sure the following can happen:
- some input stream (e.g gunzip) sends some input chunks
- user code writes these to an `extract` stream as they come in
- `extract` stream sends these to underlying `fstream`, whose buffer is now full
- `write()` returns falsy, so well-behaved user code awaits the `drain` event
- fstream at some point emits `drain`, but nobody is listening
- program awaits heat death of universe

I had this happen somewhat consistently on travis-ci (.e.g https://travis-ci.org/onilabs/stratifiedjs/jobs/42133170), but could never reproduce locally - I'm guessing some timing issue with slow / virtualized disks. I can't prove that the above is what caused my builds to fail (it just times out), but the above seems plausible and it hasn't failed since I applied this fix.
