### PR TITLE
parse: don't extract invalid entry

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -146,7 +146,7 @@ Parse.prototype._startEntry = function (c) {
     e.header = header
     e.tar_file_offset = this.position
     e.tar_block = this.position / 512
-    this.emit("error", e)
+    return this.emit("error", e)
   }
 
   switch (tar.types[header.type]) {


### PR DESCRIPTION
When parse sees an invalid entry, it emits an error and then goes ahead and extracts something anyway. I don't know what the extracted file looks like but, it's probably not good.
