### PR TITLE
Emit finish from Extract when finished.

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -71,6 +71,7 @@ function Extract (opts) {
 
   this._fst.on("close", function () {
     // console.error("\nEEEE Extract End", me._fst.path)
+    me.emit("finish")
     me.emit("end")
     me.emit("close")
   })


### PR DESCRIPTION
(Note: opening this as a PR for discussion rather than an issue since the change is so minor)

I'm thinking about `tar.Extract` as a Writeable stream and it's my understanding that writeable streams should emit `"finish"` when they're done writing. If that's not correct, feel free to close this PR!