### PR TITLE
check if we are in the middle of an entry on _streamEnd

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -88,7 +88,7 @@ inherits(Extract, tar.Parse)
 
 Extract.prototype._streamEnd = function () {
   var me = this
-  if (!me._ended) me.error("unexpected eof")
+  if (!me._ended || me._entry) me.error("unexpected eof")
   me._fst.end()
   // my .end() is coming later.
 }

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -61,7 +61,7 @@ function Parse () {
 // emitting "end"
 Parse.prototype._streamEnd = function () {
   var me = this
-  if (!me._ended) me.error("unexpected eof")
+  if (!me._ended || me._entry) me.error("unexpected eof")
   me.emit("end")
 }
 


### PR DESCRIPTION
- Fixes an issue where a truncated file will fail
  to emit 'close' or 'error'
