### PR TITLE
adding entity.abort() to stop writes from the parser

### DIFF
--- a/lib/entry.js
+++ b/lib/entry.js
@@ -24,6 +24,7 @@ function Entry (header, extended, global) {
   this._ending = false
   this._ended = false
   this._remaining = 0
+  this._discard = false
   this._queue = []
   this._index = 0
   this._queueLen = 0
@@ -207,6 +208,12 @@ Entry.prototype._setProps = function () {
 
   // size is special, since it signals when the file needs to end.
   this._remaining = props.size
+}
+
+// the parser may not call write if discard is true. 
+// useful for skipping data from some files quickly.
+Entry.prototype.discard = function(){
+  this._discard = true
 }
 
 Entry.prototype.warn = fstream.warn

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -24,7 +24,7 @@ function Entry (header, extended, global) {
   this._ending = false
   this._ended = false
   this._remaining = 0
-  this._discard = false
+  this._abort = false
   this._queue = []
   this._index = 0
   this._queueLen = 0
@@ -210,10 +210,10 @@ Entry.prototype._setProps = function () {
   this._remaining = props.size
 }
 
-// the parser may not call write if discard is true. 
+// the parser may not call write if _abort is true. 
 // useful for skipping data from some files quickly.
-Entry.prototype.discard = function(){
-  this._discard = true
+Entry.prototype.abort = function(){
+  this._abort = true
 }
 
 Entry.prototype.warn = fstream.warn

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -102,7 +102,11 @@ Parse.prototype._process = function (c) {
 
   if (this._entry) {
     var entry = this._entry
-    entry.write(c)
+    if(!entry._discard) entry.write(c)
+    else {
+      entry._remaining -= c.length
+      if(entry._remaining < 0) entry._remaining = 0
+    }
     if (entry._remaining === 0) {
       entry.end()
       this._entry = null

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -102,7 +102,7 @@ Parse.prototype._process = function (c) {
 
   if (this._entry) {
     var entry = this._entry
-    if(!entry._discard) entry.write(c)
+    if(!entry._abort) entry.write(c)
     else {
       entry._remaining -= c.length
       if(entry._remaining < 0) entry._remaining = 0

--- a/test/parse-discard.js
+++ b/test/parse-discard.js
@@ -6,8 +6,8 @@ var tap = require("tap")
 
 tap.test("parser test", function (t) {
   var parser = tar.Parse()
-  var total = 0;
-  var dataTotal = 0;
+  var total = 0
+  var dataTotal = 0
 
   parser.on("end", function () {
 

--- a/test/parse-discard.js
+++ b/test/parse-discard.js
@@ -1,0 +1,29 @@
+var tap = require("tap")
+  , tar = require("../tar.js")
+  , fs = require("fs")
+  , path = require("path")
+  , file = path.resolve(__dirname, "fixtures/c.tar")
+
+tap.test("parser test", function (t) {
+  var parser = tar.Parse()
+  var total = 0;
+  var dataTotal = 0;
+
+  parser.on("end", function () {
+
+    t.equals(total-513,dataTotal,'should have discarded only c.txt')
+
+    t.end()
+  })
+
+  fs.createReadStream(file)
+    .pipe(parser)
+    .on('entry',function(entry){
+      if(entry.path === 'c.txt') entry.discard()
+      
+      total += entry.size;
+      entry.on('data',function(data){
+        dataTotal += data.length        
+      })
+    })
+})

--- a/test/parse-discard.js
+++ b/test/parse-discard.js
@@ -19,7 +19,7 @@ tap.test("parser test", function (t) {
   fs.createReadStream(file)
     .pipe(parser)
     .on('entry',function(entry){
-      if(entry.path === 'c.txt') entry.discard()
+      if(entry.path === 'c.txt') entry.abort()
       
       total += entry.size;
       entry.on('data',function(data){


### PR DESCRIPTION
entity.abort() is a performance optimization for those using this library to only read specific files from the tar.
the parser looks at this property in the same manner it looks at _remaining to know when to skip calling write on the entity.

an entity which discard() has been called on shouldn't emit any more data events.
discard() does not take any arguments and only sets the value of _discard to true.

this saves 100ms or so for me to just stat (read the headers of each file) for all of the files in the npm v 3 tar. I wrote this because it saves hours of time examining all of the tars in npm.