### PR TITLE
deps: Upgrade graceful-fs dependency to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "inherits": "2"
   },
   "devDependencies": {
-    "graceful-fs": "^3.0.2",
+    "graceful-fs": "^4.1.2",
     "rimraf": "1.x",
     "tap": "0.x",
     "mkdirp": "^0.5.0"


### PR DESCRIPTION
graceful-fs used to monkey-patch node's core fs module.
This has been fixed in the version 4.

Related: https://github.com/nodejs/node/pull/2714