### PR TITLE
Fix loop condition in Parse.prototype.write

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -73,7 +73,7 @@ Parse.prototype.write = function (c) {
     // gnutar puts a LOT of nulls at the end.
     // you can keep writing these things forever.
     // Just ignore them.
-    for (var i = 0, l = c.length; i > l; i ++) {
+    for (var i = 0, l = c.length; i < l; i ++) {
       if (c[i] !== 0) return this.error("write() after end()")
     }
     return


### PR DESCRIPTION
The existing loop condition in `Parse.prototype.write` causes the loop to never
execute: `i > l` is never true because `l = c.length >= 0` and `i = 0`.
