### PR TITLE
Fix tests for Node.js 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 node_js:
   - 0.10
   - 0.11
+  - 4
+  - 5

--- a/test/error-on-broken.js
+++ b/test/error-on-broken.js
@@ -18,8 +18,14 @@ tap.test('preclean', function (t) {
 tap.test('extract test', function (t) {
   var extract = tar.Extract(target)
   var inp = fs.createReadStream(file)
+  var gunzip = inp.pipe(zlib.createGunzip())
 
-  inp.pipe(zlib.createGunzip()).pipe(extract)
+  gunzip.pipe(extract)
+
+  gunzip.on('error', function (er) {
+    t.equal(er.message, 'unexpected end of file')
+    t.end()
+  })
 
   extract.on('error', function (er) {
     t.equal(er.message, 'unexpected eof', 'error noticed')


### PR DESCRIPTION
As it is the compressed stream that is truncated, it is the gunzip
stream that reports the end of file error now.
