### PR TITLE
added .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+test
+examples


### PR DESCRIPTION
specifically this is useful for users with antivirus scanners
complaining when this package is used as a dependency because one of the
test files contains an encrypted tarball
