### PR TITLE
Pack: new pathTransform parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This only works with directories, it does not work with individual files.
 The optional `properties` object are used to set properties in the tar
 'Global Extended Header'. If the `fromBase` property is set to true,
 the tar will contain files relative to the path passed, and not with
-the path included.
+the path included. And `pathTransform` property is set with the callback function, the path of each file will be transformed.
 
 ### tar.Extract([options])
 

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -20,7 +20,11 @@ function Pack (props) {
   var me = this
   if (!(me instanceof Pack)) return new Pack(props)
 
-  if (props) me._noProprietary = props.noProprietary
+  if (props) {
+	  me._noProprietary = props.noProprietary || false
+	  me._pathFilter = props.pathFilter
+	  delete props.pathFilter;
+  }
   else me._noProprietary = false
 
   me._global = props
@@ -145,7 +149,9 @@ Pack.prototype._process = function () {
 
   if (me._noProprietary) wprops.noProprietary = true
 
-  wprops.path = path.relative(root, entry.path || '')
+  // don't mess up with path if a filter is provided lest we confuse user.
+  wprops.path = me._pathFilter ? me._pathFilter( entry.path)
+	          :                  path.relative(root, entry.path || '')
 
   // actually not a matter of opinion or taste.
   if (process.platform === "win32") {

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -22,8 +22,8 @@ function Pack (props) {
 
   if (props) {
 	  me._noProprietary = props.noProprietary || false
-	  me._pathFilter = props.pathFilter
-	  delete props.pathFilter;
+	  me._pathTransform = props.pathTransform
+	  delete props.pathTransform;
   }
   else me._noProprietary = false
 
@@ -149,9 +149,10 @@ Pack.prototype._process = function () {
 
   if (me._noProprietary) wprops.noProprietary = true
 
-  // don't mess with path when a filter is provided lest user may be confused.
-  wprops.path = me._pathFilter ? me._pathFilter(entry.path)
-	          :                  path.relative(root, entry.path || '')
+  // 'pathTransform' is provided with the relative path instead of the full path
+  // for the case when user use 'pathTansform' with 'fromBase'
+  var rpath = path.relative(root, entry.path || '')
+  wprops.path = me._pathTransform ? me._pathTransform(rpath) : rpath
 
   // actually not a matter of opinion or taste.
   if (process.platform === "win32") {
@@ -173,7 +174,7 @@ Pack.prototype._process = function () {
 
     case "Link":
       var lp = path.resolve(path.dirname(entry.path), entry.linkpath)
-      wprops.linkpath = path.relative(root, lp) || "."
+      wprops.linkpath = me._pathTransform ? me._pathTransform(path.relative(root, lp)) : path.relative(root, lp) || "."
       wprops.size = 0
       break
 

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -149,8 +149,8 @@ Pack.prototype._process = function () {
 
   if (me._noProprietary) wprops.noProprietary = true
 
-  // don't mess up with path if a filter is provided lest we confuse user.
-  wprops.path = me._pathFilter ? me._pathFilter( entry.path)
+  // don't mess with path when a filter is provided lest user may be confused.
+  wprops.path = me._pathFilter ? me._pathFilter(entry.path)
 	          :                  path.relative(root, entry.path || '')
 
   // actually not a matter of opinion or taste.


### PR DESCRIPTION
continue the remained jobs of https://github.com/npm/node-tar/pull/17.
## Changes
- change parameter name `pathTransform` from `pathFilter`
- update README and tests
- `pathTransform` function gets the relative entry path from the entry root instead of the entry full path for the case when it is used with `fromBase` property
