### PR TITLE
Removed octal literals

### DIFF
--- a/lib/extended-header-writer.js
+++ b/lib/extended-header-writer.js
@@ -26,7 +26,7 @@ function ExtendedHeaderWriter (props) {
   var p =
     { path : ("PaxHeader" + path.join("/", props.path || ""))
              .replace(/\\/g, "/").substr(0, 100)
-    , mode : props.mode || 0666
+    , mode : props.mode || parseInt('0666', 8)
     , uid : props.uid || 0
     , gid : props.gid || 0
     , size : 0 // will be set later

--- a/lib/header.js
+++ b/lib/header.js
@@ -55,7 +55,7 @@ function encode (obj) {
 
   if (obj.mode) {
     if (typeof obj.mode === "string") obj.mode = parseInt(obj.mode, 8)
-    obj.mode = obj.mode & 0777
+    obj.mode = obj.mode & parseInt('0777', 8)
   }
 
   for (var f = 0; fields[f] !== null; f ++) {
@@ -153,10 +153,10 @@ function encode (obj) {
 
 // if it's a negative number, or greater than will fit,
 // then use write256.
-var MAXNUM = { 12: 077777777777
-             , 11: 07777777777
-             , 8 : 07777777
-             , 7 : 0777777 }
+var MAXNUM = { 12: parseInt('077777777777', 8)
+             , 11: parseInt('07777777777', 8)
+             , 8 : parseInt('07777777', 8)
+             , 7 : parseInt('0777777', 8) }
 function writeNumeric (block, off, end, num) {
   var writeLen = end - off
     , maxNum = MAXNUM[writeLen] || 0

--- a/tar.js
+++ b/tar.js
@@ -105,19 +105,19 @@ Object.keys(types).forEach(function (t) {
 
 // values for the mode field
 var modes =
-  { suid: 04000 // set uid on extraction
-  , sgid: 02000 // set gid on extraction
-  , svtx: 01000 // set restricted deletion flag on dirs on extraction
-  , uread:  0400
-  , uwrite: 0200
-  , uexec:  0100
-  , gread:  040
-  , gwrite: 020
-  , gexec:  010
-  , oread:  4
-  , owrite: 2
-  , oexec:  1
-  , all: 07777
+  { suid: parseInt('04000', 8) // set uid on extraction
+  , sgid: parseInt('02000', 8) // set gid on extraction
+  , svtx: parseInt('01000', 8) // set restricted deletion flag on dirs on extraction
+  , uread:  parseInt('0400', 8)
+  , uwrite: parseInt('0200', 8)
+  , uexec:  parseInt('0100', 8)
+  , gread:  parseInt('040', 8)
+  , gwrite: parseInt('020', 8)
+  , gexec:  parseInt('010', 8)
+  , oread:  parseInt('4', 8)
+  , owrite: parseInt('2', 8)
+  , oexec:  parseInt('1', 8)
+  , all: parseInt('07777', 8)
   }
 
 var numeric =


### PR DESCRIPTION
When running in strict mode, Node (v6.6.0) throws a fit over the fact that the code uses 'octal literals' (i.e `0666` and `07777777`, basically anything in base 8). The proper way to handle this is to use `parseInt('octal', 8)` which then converts it to the correct number, instead of just writing them out in the code.  This pull request has changed every appearance of octals to use the correct method.

Tested successfully on v6.6.0, Windows x64 (can't see why it shouldn't work everywhere though but don't mind doing more testing if required). If people want a working version of this library and this PR hasn't been merged you can find the fork at https://github.com/nickdbush/node-tar
