### PR TITLE
Switch to strict mode

### DIFF
--- a/lib/buffer-entry.js
+++ b/lib/buffer-entry.js
@@ -1,3 +1,4 @@
+"use strict"
 // just like the Entry class, but it buffers the contents
 //
 // XXX It would be good to set a maximum BufferEntry filesize,

--- a/lib/entry-writer.js
+++ b/lib/entry-writer.js
@@ -1,3 +1,4 @@
+"use strict"
 module.exports = EntryWriter
 
 var tar = require("../tar.js")

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -1,3 +1,4 @@
+"use strict"
 // A passthrough read/write stream that sets its properties
 // based on a header, extendedHeader, and globalHeader
 //

--- a/lib/extended-header-writer.js
+++ b/lib/extended-header-writer.js
@@ -26,7 +26,7 @@ function ExtendedHeaderWriter (props) {
   var p =
     { path : ("PaxHeader" + path.join("/", props.path || ""))
              .replace(/\\/g, "/").substr(0, 100)
-    , mode : props.mode || 0666
+    , mode : props.mode || 438 // 0666
     , uid : props.uid || 0
     , gid : props.gid || 0
     , size : 0 // will be set later

--- a/lib/extended-header-writer.js
+++ b/lib/extended-header-writer.js
@@ -1,4 +1,4 @@
-
+"use strict"
 module.exports = ExtendedHeaderWriter
 
 var inherits = require("inherits")

--- a/lib/extended-header.js
+++ b/lib/extended-header.js
@@ -1,3 +1,4 @@
+"use strict"
 // An Entry consisting of:
 //
 // "%d %s=%s\n", <length>, <keyword>, <value>

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -1,3 +1,4 @@
+"use strict"
 // give it a tarball and a path, and it'll dump the contents
 
 module.exports = Extract

--- a/lib/global-header-writer.js
+++ b/lib/global-header-writer.js
@@ -1,3 +1,4 @@
+"use strict"
 module.exports = GlobalHeaderWriter
 
 var ExtendedHeaderWriter = require("./extended-header-writer.js")

--- a/lib/header.js
+++ b/lib/header.js
@@ -55,7 +55,7 @@ function encode (obj) {
 
   if (obj.mode) {
     if (typeof obj.mode === "string") obj.mode = parseInt(obj.mode, 8)
-    obj.mode = obj.mode & 0777
+    obj.mode = obj.mode & 511 // 0777
   }
 
   for (var f = 0; fields[f] !== null; f ++) {
@@ -153,10 +153,11 @@ function encode (obj) {
 
 // if it's a negative number, or greater than will fit,
 // then use write256.
-var MAXNUM = { 12: 077777777777
-             , 11: 07777777777
-             , 8 : 07777777
-             , 7 : 0777777 }
+var MAXNUM = { 12: 8589934591 // 077777777777
+             , 11: 1073741823 // 07777777777
+             , 8 : 2097151 // 07777777
+             , 7 : 262143 // 0777777
+           }
 function writeNumeric (block, off, end, num) {
   var writeLen = end - off
     , maxNum = MAXNUM[writeLen] || 0

--- a/lib/header.js
+++ b/lib/header.js
@@ -1,3 +1,4 @@
+"use strict"
 // parse a 512-byte header block to a data object, or vice-versa
 // If the data won't fit nicely in a simple header, then generate
 // the appropriate extended header file, and return that.

--- a/lib/header.js
+++ b/lib/header.js
@@ -111,8 +111,8 @@ function encode (obj) {
           }
 
           if (found !== false) {
-            prefix = pathBuf.slice(0, found).toString("utf8")
-            path = pathBuf.slice(found + 1).toString("utf8")
+            var prefix = pathBuf.slice(0, found).toString("utf8")
+            var path = pathBuf.slice(found + 1).toString("utf8")
 
             ret = writeText(block, off, end, path)
             off = fieldOffs[fields.prefix]

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -1,3 +1,4 @@
+"use strict"
 // pipe in an fstream, and it'll make a tarball.
 // key-value pair argument is global extended header props.
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,4 +1,5 @@
 
+"use strict"
 // A writable stream.
 // It emits "entry" events, which provide a readable stream that has
 // header info attached.

--- a/tar.js
+++ b/tar.js
@@ -1,3 +1,5 @@
+"use strict"
+
 // field paths that every tar file must have.
 // header is padded to 512 bytes.
 var f = 0

--- a/tar.js
+++ b/tar.js
@@ -105,19 +105,19 @@ Object.keys(types).forEach(function (t) {
 
 // values for the mode field
 var modes =
-  { suid: 04000 // set uid on extraction
-  , sgid: 02000 // set gid on extraction
-  , svtx: 01000 // set restricted deletion flag on dirs on extraction
-  , uread:  0400
-  , uwrite: 0200
-  , uexec:  0100
-  , gread:  040
-  , gwrite: 020
-  , gexec:  010
+  { suid: 2048 // 04000 set uid on extraction
+  , sgid: 1024 // 02000 set gid on extraction
+  , svtx: 512 // 01000 set restricted deletion flag on dirs on extraction
+  , uread: 256 // 0400
+  , uwrite: 128 // 0200
+  , uexec: 64 // 0100
+  , gread: 32 // 040
+  , gwrite: 16 // 020
+  , gexec: 8 // 010
   , oread:  4
   , owrite: 2
   , oexec:  1
-  , all: 07777
+  , all: 4095 // 07777
   }
 
 var numeric =


### PR DESCRIPTION
For use with js packagers and transpilers that throw the global scope into strict mode.

Alternative to https://github.com/npm/node-tar/pull/76 closes #74 