### PR TITLE
fix docs for tar.Parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,8 @@ The following options are supported:
   archive, or `false` to skip it.
 - `onentry` A function that gets called with `(entry)` for each entry
   that passes the filter.
+- `onwarn` A function that will get called with `(message, data)` for
+  any warnings encountered.
 
 #### abort(message, error)
 

--- a/README.md
+++ b/README.md
@@ -579,8 +579,6 @@ Returns an event emitter that emits `entry` events with
 
 The following options are supported:
 
-- `cwd` Extract files relative to the specified directory.  Defaults
-  to `process.cwd()`.
 - `strict` Treat warnings as crash-worthy errors.  Default false.
 - `filter` A function that gets called with `(path, entry)` for each
   entry being listed.  Return `true` to emit the entry from the


### PR DESCRIPTION
The `tar.Parse` constructor description listed `cwd` (which doesn't exist) and missed `onwarn`.