### PR TITLE
package: mark as requiring node v4+

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "tar-stream": "^1.5.2"
   },
   "license": "ISC",
+  "engines": {
+    "node": ">=4"
+  },
   "files": [
     "index.js",
     "lib/"


### PR DESCRIPTION
This way users will at least get a warning that this package requires
node v4+ instead of only finding out when it bails on first load.