### PR TITLE
require node 4.5 as minimum

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "license": "ISC",
   "engines": {
-    "node": ">=4"
+    "node": ">=4.5"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
`Buffer.alloc` does not exist in `4.4`, and fails.