### PR TITLE
unpack: open file handle only once

### DIFF
--- a/lib/unpack.js
+++ b/lib/unpack.js
@@ -32,6 +32,8 @@ const DOCHOWN = Symbol('doChown')
 const UID = Symbol('uid')
 const GID = Symbol('gid')
 
+const MAX_SIZE = 1024 * 1024 // 1MB
+
 class Unpack extends Parser {
   constructor (opt) {
     if (!opt)
@@ -237,11 +239,16 @@ class Unpack extends Parser {
 
   [FILE] (entry) {
     const mode = entry.mode & 0o7777 || this.fmode
-    const stream = fs.createWriteStream(entry.absolute, { mode: mode })
-    stream.on('error', er => this[ONERROR](er, entry))
-
     const queue = []
-    const processQueue = _ => {
+    let fd
+    const processQueue = err => {
+      if (err && fd != null) {
+        this[ONERROR](err, entry)
+        return fs.close(fd, _ => {
+          fd = null
+          processQueue()
+        })
+      }
       const action = queue.shift()
       if (action)
         action(processQueue)
@@ -249,16 +256,58 @@ class Unpack extends Parser {
         this[UNPEND]()
     }
 
-    stream.on('close', _ => {
-      if (entry.mtime && !this.noMtime)
+    if (entry.size < MAX_SIZE) {
+      // If the entry is small enough, we can skip all the stream stuff and
+      // do as much as possible on the libuv side -- as well as only ever
+      // opening the file handle once.
+      let data = []
+      let dataLen = 0
+      entry.on('end', () => {
+        queue.push(cb => {
+          fs.open(entry.absolute, 'w', mode, (err, _fd) => {
+            if (err) {
+              cb(err)
+            } else {
+              fd = _fd
+              cb(null)
+            }
+          })
+        })
         queue.push(cb =>
-          fs.utimes(entry.absolute, entry.atime || new Date(), entry.mtime, cb))
-      if (this[DOCHOWN](entry))
-        queue.push(cb =>
-          fs.chown(entry.absolute, this[UID](entry), this[GID](entry), cb))
-      processQueue()
-    })
-    entry.pipe(stream)
+          fs.write(fd, Buffer.concat(data, dataLen), 0, dataLen, 0, cb)
+        )
+        if (entry.mtime && !this.noMtime) {
+          queue.push(cb =>
+            fs.futimes(fd, entry.atime || new Date(), entry.mtime, cb)
+          )
+        }
+        if (this[DOCHOWN](entry)) {
+          queue.push(cb =>
+            fs.fchown(fd, this[UID](entry), this[GID](entry), cb)
+          )
+        }
+        queue.push(cb => fs.close(fd, cb))
+        processQueue()
+      })
+      entry.on('data', d => {
+        data.push(d)
+        dataLen += d.length
+      })
+    } else {
+      const stream = fs.createWriteStream(entry.absolute, { mode: mode })
+      stream.on('error', er => this[ONERROR](er, entry))
+
+      stream.on('close', _ => {
+        if (entry.mtime && !this.noMtime)
+          queue.push(cb =>
+            fs.utimes(entry.absolute, entry.atime || new Date(), entry.mtime, cb))
+        if (this[DOCHOWN](entry))
+          queue.push(cb =>
+            fs.chown(entry.absolute, this[UID](entry), this[GID](entry), cb))
+        processQueue()
+      })
+      entry.pipe(stream)
+    }
   }
 
   [DIRECTORY] (entry) {

--- a/test/unpack.js
+++ b/test/unpack.js
@@ -100,7 +100,7 @@ t.test('basic file unpack tests', t => {
         t.test('strict', t => {
           const unpack = new Unpack({ cwd: dir, strict: true })
           fs.createReadStream(tf).pipe(unpack)
-          eos(unpack, _ => check(t))
+          eos(unpack, err => check(t))
         })
         t.test('loose', t => {
           const unpack = new Unpack({ cwd: dir })


### PR DESCRIPTION
This gives a significant speed boost, specially when doing chown and utimes operations, by reducing the number of fd open+close ops.

Note: this PR is still WIP while I figure out why tests are failing. It looks like error handling needs to change and the stuff you see for handling errors right now is mostly me flopping around trying to figure out the issue.

This PR is inspired by https://github.com/yarnpkg/yarn/pull/4486, which did this for Yarn's own extraction and it had a pretty neat speed boost! 🎉 

### Benchmarks
#### Before
```
benchmarks/extract/node-tar-file-async.js
791.322
844.052
887.71
898.871
924.761
benchmarks/extract/node-tar-stream-sync.js
1089.522
1122.212
1077.03
1045.234
1009.606
```
#### After
```
benchmarks/extract/node-tar-file-async.js
619.741
654.146
638.94
657.804
708.489
benchmarks/extract/node-tar-stream-async.js
793.267
779.895
736.296
718.423
777.464
```