### PR TITLE
Fallback to zlib from minizlib on Node 9

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -23,7 +23,7 @@ class PackJob {
 }
 
 const MiniPass = require('minipass')
-const zlib = require('minizlib')
+const zlib = require('../lib/zlib.js')
 const ReadEntry = require('./read-entry.js')
 const WriteEntry = require('./write-entry.js')
 const WriteEntrySync = WriteEntry.Sync

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -28,7 +28,7 @@ const Yallist = require('yallist')
 const maxMetaEntrySize = 1024 * 1024
 const Entry = require('./read-entry.js')
 const Pax = require('./pax.js')
-const zlib = require('minizlib')
+const zlib = require('./zlib.js')
 
 const gzipHeader = new Buffer([0x1f, 0x8b])
 const STATE = Symbol('state')

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -1,0 +1,9 @@
+'use strict'
+const semver = require('semver')
+
+module.exports = select(process.version)
+module.exports._SELECT_ZLIB = select
+
+function select (version) {
+  return semver.gt(version, 'v9.0.0-0') ? require('zlib') : require('minizlib')
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2639,6 +2639,11 @@
       "integrity": "sha512-aSLEDudu6OoRr/2rU609gRmnYboRLxgDG1z9o2Q0os7236FwvcqIOO8r8U5JUEwivZOhDaKlFO4SbPTJYyBEyQ==",
       "dev": true
     },
+    "semver": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "minipass": "^2.0.2",
     "minizlib": "^1.0.3",
     "mkdirp": "^0.5.0",
+    "semver": "^5.4.1",
     "yallist": "^3.0.2"
   },
   "devDependencies": {

--- a/test/parse.js
+++ b/test/parse.js
@@ -508,10 +508,15 @@ t.test('truncated gzip input', t => {
     const p = new Parse({ onwarn: message => warnings.push(message) })
     let aborted = false
     p.on('abort', _ => aborted = true)
+    p.on('abort', onEnd)
+    p.on('error', onEnd)
+    p.on('end', onEnd)
     p.end(trunc)
-    t.equal(aborted, true, 'aborted writing')
-    t.same(warnings, [ 'zlib error: unexpected end of file' ])
-    t.end()
+    function onEnd () {
+      t.equal(aborted, true, 'aborted writing')
+      t.same(warnings, [ 'zlib error: unexpected end of file' ])
+      t.end()
+    }
   })
 
   t.test('just wrong', t => {
@@ -519,13 +524,18 @@ t.test('truncated gzip input', t => {
     const p = new Parse({ onwarn: message => warnings.push(message) })
     let aborted = false
     p.on('abort', _ => aborted = true)
+    p.on('abort', onEnd)
+    p.on('error', onEnd)
+    p.on('end', onEnd)
     p.write(trunc)
     p.write(trunc)
     p.write(tgz.slice(split))
     p.end()
-    t.equal(aborted, true, 'aborted writing')
-    t.same(warnings, [ 'zlib error: incorrect data check' ])
-    t.end()
+    function onEnd () {
+      t.equal(aborted, true, 'aborted writing')
+      t.same(warnings, [ 'zlib error: incorrect data check' ])
+      t.end()
+    }
   })
 
   t.end()

--- a/test/select-zlib.js
+++ b/test/select-zlib.js
@@ -1,0 +1,15 @@
+'use strict'
+const zlib = require('zlib')
+const minizlib = require('minizlib')
+const szlib = require('../lib/zlib.js')
+const select = szlib._SELECT_ZLIB
+const test = require('tap').test
+
+test('select the right zlib', t => {
+  t.is(select('v8.5.0'), minizlib, 'older nodes get faster zlib')
+  t.is(select('v9.0.0-pre'), zlib, 'newer nodes get compat zlib')
+  t.is(select('v9.1.0'), zlib, 'non-pre newer nodes get compat zlib')
+  t.is(select('v10.0.0-pre'), zlib, 'even newer pre-release nodes get compat zlib')
+  t.is(select('v10.0.0'), zlib, 'even newer nodes get compat zlib')
+  t.end()
+})

--- a/test/unpack.js
+++ b/test/unpack.js
@@ -8,7 +8,7 @@ const t = require('tap')
 
 const makeTar = require('./make-tar.js')
 const Header = require('../lib/header.js')
-const z = require('minizlib')
+const z = require('../lib/zlib.js')
 const fs = require('fs')
 const path = require('path')
 const fixtures = path.resolve(__dirname, 'fixtures')


### PR DESCRIPTION
Does what it says, gives us an escape valve if minizlib can't be made to work w/ Node 9.

I've tested this with my own build of the `v9.x` branch of Node as of [7e382c1540](https://github.com/nodejs/node/tree/7e382c1540).