### PR TITLE
unpack: don't unpend if an error occurred

### DIFF
--- a/lib/unpack.js
+++ b/lib/unpack.js
@@ -198,9 +198,10 @@ class Unpack extends Parser {
     // Cwd has to exist, or else nothing works. That's serious.
     // Other errors are warnings, which raise the error in strict
     // mode, but otherwise continue on.
+    // Don't raise an error if 'fs.futime()' is not impleted (e.g AIX 7.1).
     if (er.name === 'CwdError')
       this.emit('error', er)
-    else {
+    else if (er.syscall !== 'futime'){
       this.warn(er.message, er)
       this[UNPEND]()
       entry.resume()


### PR DESCRIPTION
fs.futimes is not implemented on AIX, this causes an error. For some
reason the this.warn() at
https://github.com/npm/node-tar/blob/51b6e83761dedcce661404819571779cefd35d04/lib/unpack.js#L204
doesn't show up, and the `this[UNPEND]()` causes `this[PENDING]` to go
negative.

Since the PENDING check doesn't cover negative values, the stream never closes.

This means that a simple test-case:

```js
const tar = require('tar')
tar.extract({ file: 'express-4.16.2.tar'})
  .then(x => { console.log(x, 'done'); },
        x => { console.log(x, 'failed'); })
```

returns without logging success or error when the `fs.futimes()` call
fails.

cc/ @gibfahn

Refs: https://nodejs.org/dist/latest/docs/api/fs.html#fs_fs_futimes_fd_atime_mtime_callback
Refs: https://github.com/npm/node-tar/issues/164
Refs: https://github.com/nodejs/citgm/issues/525