### PR TITLE
fix join file delimeter

### DIFF
--- a/lib/header.js
+++ b/lib/header.js
@@ -204,7 +204,8 @@ const splitPrefix = (p, prefixSize) => {
 
       else {
         // make path take a bit from prefix
-        pp = pathModule.join(pathModule.basename(prefix), pp)
+        // pp = pathModule.join(pathModule.basename(prefix), pp)
+        pp = pathModule.basename(prefix) + '/' + pp;
         prefix = pathModule.dirname(prefix)
       }
     } while (prefix !== root && !ret)


### PR DESCRIPTION
The join method of node's path module uses the platform specific path seperator. On windows this means that '\\' gets inserted and is written in the tar archive.

If unpacked on linux/unix this causes that no directories are created, but insteadt files that have '\\' in the middle of their filenames.

