### PR TITLE
Use Buffer.from instead of 'new Buffer'

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -30,7 +30,7 @@ const Entry = require('./read-entry.js')
 const Pax = require('./pax.js')
 const zlib = require('minizlib')
 
-const gzipHeader = new Buffer([0x1f, 0x8b])
+const gzipHeader = Buffer.from([0x1f, 0x8b])
 const STATE = Symbol('state')
 const WRITEENTRY = Symbol('writeEntry')
 const READENTRY = Symbol('readEntry')


### PR DESCRIPTION
`Buffer()` constructor is deprecated.

Refs: https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor

Note: this does not cover tests/benchmarks.

Supported Node.js range is not affected, `Buffer.alloc` is used already and the minimum required Node.js version is 4.5.0.

This is one of the three changes needed to keep `npm i` working under `NODE_PENDING_DEPRECATION=1` without warnings. The other two are https://github.com/mafintosh/flush-write-stream/pull/3 and https://github.com/mafintosh/duplexify/pull/17.