### PR TITLE
fix path in ADDFSENTRY

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -151,11 +151,11 @@ const Pack = warner(class Pack extends MiniPass {
   }
 
   [ADDFSENTRY] (p) {
-    const absolute = path.resolve(this.cwd, p)
+    const absolute = path.resolve(this.cwd, p.path)
     if (this.prefix)
-      p = this.prefix + '/' + p.replace(/^\.(\/+|$)/, '')
+      p.path = this.prefix + '/' + p.path.replace(/^\.(\/+|$)/, '')
 
-    this[QUEUE].push(new PackJob(p, absolute))
+    this[QUEUE].push(new PackJob(p.path, absolute))
     this[PROCESS]()
   }
 


### PR DESCRIPTION
It should be path here but `p` is an object. Changed to `p.path` just like `ADDTARENTRY`.