### PR TITLE
ability to handle edge case: file shrink after lstat

### DIFF
--- a/lib/write-entry.js
+++ b/lib/write-entry.js
@@ -231,7 +231,15 @@ const WriteEntry = warner(class WriteEntry extends MiniPass {
       er.path = this.absolute
       er.syscall = 'read'
       er.code = 'EOF'
-      this.emit('error', er)
+      return this.emit('error', er)
+    }
+
+    if (bytesRead > remain) {
+      const er = new Error('expected EOF')
+      er.path = this.absolute
+      er.syscall = 'read'
+      er.code = 'EOF'
+      return this.emit('error', er)
     }
 
     // null out the rest of the buffer, if we could fit the block padding

--- a/lib/write-entry.js
+++ b/lib/write-entry.js
@@ -231,7 +231,7 @@ const WriteEntry = warner(class WriteEntry extends MiniPass {
       er.path = this.absolute
       er.syscall = 'read'
       er.code = 'EOF'
-      return this.emit('error', er)
+      return this[CLOSE](fd, _ => this.emit('error', er))
     }
 
     if (bytesRead > remain) {
@@ -239,7 +239,7 @@ const WriteEntry = warner(class WriteEntry extends MiniPass {
       er.path = this.absolute
       er.syscall = 'read'
       er.code = 'EOF'
-      return this.emit('error', er)
+      return this[CLOSE](fd, _ => this.emit('error', er))
     }
 
     // null out the rest of the buffer, if we could fit the block padding

--- a/test/write-entry.js
+++ b/test/write-entry.js
@@ -554,6 +554,24 @@ t.test('read invalid EOF', t => {
   })
 })
 
+t.test('read overflow expectation', t => {
+  t.tearDown(mutateFS.statMutate((er, st) => {
+    if (st)
+      st.size = 3
+  }));
+  const f = '512-bytes.txt'
+  const expect = {
+    message: 'expected EOF',
+    path: path.resolve(files, f),
+    syscall: 'read',
+    code: 'EOF'
+  }
+  new WriteEntry(f, { cwd: files, maxReadSize: 2 }).on('error', er => {
+    t.match(er, expect)
+    t.end()
+  })
+})
+
 t.test('short reads', t => {
   t.tearDown(mutateFS.zenoRead())
   const cases = {


### PR DESCRIPTION
when file expands after lstat, `EOF` error fires, but when file shrinks, it calls `[READ]` indefinitely.
added test.