### PR TITLE
write-entry: handle shrinked file size than expected by lstat

### DIFF
--- a/lib/write-entry.js
+++ b/lib/write-entry.js
@@ -231,7 +231,17 @@ const WriteEntry = warner(class WriteEntry extends MiniPass {
       er.path = this.absolute
       er.syscall = 'read'
       er.code = 'EOF'
-      this.emit('error', er)
+      this[CLOSE](fd)
+      return this.emit('error', er)
+    }
+
+    if (bytesRead > remain) {
+      const er = new Error('expected EOF')
+      er.path = this.absolute
+      er.syscall = 'read'
+      er.code = 'EOF'
+      this[CLOSE](fd)
+      return this.emit('error', er)
     }
 
     // null out the rest of the buffer, if we could fit the block padding

--- a/test/write-entry.js
+++ b/test/write-entry.js
@@ -554,6 +554,25 @@ t.test('read invalid EOF', t => {
   })
 })
 
+t.test('read overflow expectation', t => {
+  t.tearDown(mutateFS.statMutate((er, st) => {
+    if (st)
+      st.size = 3
+  }));
+  const f = '512-bytes.txt'
+  const expect = {
+    message: 'expected EOF',
+    path: path.resolve(files, f),
+    syscall: 'read',
+    code: 'EOF'
+  }
+  t.throws(_ => new WriteEntry.Sync(f, { cwd: files, maxReadSize: 2 }), expect)
+  new WriteEntry(f, { cwd: files, maxReadSize: 2 }).on('error', er => {
+    t.match(er, expect)
+    t.end()
+  })
+})
+
 t.test('short reads', t => {
   t.tearDown(mutateFS.zenoRead())
   const cases = {


### PR DESCRIPTION
if file expands after lstat, EOF error thrown.
but if file shrinks after lstat, [READ] will called indefinitely.

- added test
- [ONREAD] should [CLOSE] fd before emit, same as on [READ]