### PR TITLE
Attempt to fix v2 file overwrite vulnerability

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -38,6 +38,7 @@ function Parse () {
   me._stream = new BlockStream(512)
   me.position = 0
   me._ended = false
+  me._entries = []
 
   me._stream.on("error", function (e) {
     me.emit("error", e)
@@ -250,7 +251,16 @@ Parse.prototype._startEntry = function (c) {
 
   if (onend) entry.on("end", onend)
 
+  if (entry.type === "File") {
+    this._entries.forEach(function(prevEntry) {
+      if (prevEntry.type === "Link" && prevEntry.path === entry.path) {
+        ev = "ignoredEntry"
+      }
+    })
+  }
+
   this._entry = entry
+  this._entries.push(entry)
   var me = this
 
   entry.on("pause", function () {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -38,7 +38,7 @@ function Parse () {
   me._stream = new BlockStream(512)
   me.position = 0
   me._ended = false
-  me._entries = []
+  me._hardLinks = []
 
   me._stream.on("error", function (e) {
     me.emit("error", e)
@@ -252,15 +252,19 @@ Parse.prototype._startEntry = function (c) {
   if (onend) entry.on("end", onend)
 
   if (entry.type === "File") {
-    this._entries.forEach(function(prevEntry) {
-      if (prevEntry.type === "Link" && prevEntry.path === entry.path) {
+    this._hardLinks.forEach(function(link) {
+      if (link.path === entry.path) {
         ev = "ignoredEntry"
       }
     })
   }
 
   this._entry = entry
-  this._entries.push(entry)
+
+  if (entry.type === "Link") {
+    this._hardLinks.push(entry)
+  }
+
   var me = this
 
   entry.on("pause", function () {


### PR DESCRIPTION
This is an attempt at fixing #212. The basic idea behind the change is that it ignores any files in the tar that _might_ be potentially unsafe to write (a file is considered potentially unsafe to write if a hardlink with the same path was previously seen in the tar). This might make tar extraction with hardlinks not work as expected, but, as I pointed out in #212, v2 already has a buggy implementation of tar extraction with hardlinks. Even so, this logic will only be run if there happens to be a hardlink in the tar with the same path as a file later in that tar, and, outside of malicious tars, I doubt this happens.

If anyone else has any ideas for how to potentially fix this please let me know. My main concerns with this fix are the one I mentioned above ~~and having to run through all previous entries for each entry.~~

EDIT: I updated the code so that it only keeps track of hardlinks seen, so now it only goes through previously seen hardlinks for each file instead of going through each previously seen entry