### PR TITLE
Use `stat` instead of `lstat` when checking CWD (fixes #204)

### DIFF
--- a/lib/mkdir.js
+++ b/lib/mkdir.js
@@ -69,7 +69,7 @@ const mkdir = module.exports = (dir, opt, cb) => {
     return done()
 
   if (dir === cwd)
-    return fs.lstat(dir, (er, st) => {
+    return fs.stat(dir, (er, st) => {
       if (er || !st.isDirectory())
         er = new CwdError(dir, er && er.code || 'ENOTDIR')
       done(er)


### PR DESCRIPTION
I had the problem of it not working when the CWD was a symbolic link. Can't see any reason to use `lstat` instead of `stat` here?