### PR TITLE
unpack: accept fflag as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ advanced use cases, such as re-using caches between runs.
   Defaults to 16 MB.
 - `umask` Filter the modes of entries like `process.umask()`.
 - `dmode` Default mode for directories
+- `fflag` Default flag for files
 - `fmode` Default mode for files
 - `dirCache` A Map object of which directories exist.
 - `maxMetaEntrySize` The maximum size of meta entries that is
@@ -599,6 +600,7 @@ Most unpack errors will cause a `warn` event to be emitted.  If the
   any warnings encountered.
 - `umask` Filter the modes of entries like `process.umask()`.
 - `dmode` Default mode for directories
+- `fflag` Default flag for files
 - `fmode` Default mode for files
 - `dirCache` A Map object of which directories exist.
 - `maxMetaEntrySize` The maximum size of meta entries that is

--- a/benchmarks/extract/node-tar-fmap-async.js
+++ b/benchmarks/extract/node-tar-fmap-async.js
@@ -1,0 +1,17 @@
+const cwd = __dirname + '/cwd'
+const rimraf = require('rimraf')
+rimraf.sync(cwd)
+require('mkdirp').sync(cwd)
+process.on('exit', _ => rimraf.sync(cwd))
+const path = require('path')
+const file = process.argv[2] || path.resolve(__dirname, '../npm.tar')
+const fs = require('fs')
+const { O_CREAT, O_TRUNC, O_WRONLY, UV_FS_O_FILEMAP } = fs.constants
+
+const tar = require('../..')
+const timer = require('../timer.js')()
+tar.x({
+  fflag: (UV_FS_O_FILEMAP | O_TRUNC | O_CREAT | O_WRONLY),
+  file: file,
+  cwd: cwd
+}).then(timer)

--- a/benchmarks/extract/node-tar-fmap-async.js
+++ b/benchmarks/extract/node-tar-fmap-async.js
@@ -6,7 +6,7 @@ process.on('exit', _ => rimraf.sync(cwd))
 const path = require('path')
 const file = process.argv[2] || path.resolve(__dirname, '../npm.tar')
 const fs = require('fs')
-const { O_CREAT, O_TRUNC, O_WRONLY, UV_FS_O_FILEMAP } = fs.constants
+const { O_CREAT, O_TRUNC, O_WRONLY, UV_FS_O_FILEMAP = 0 } = fs.constants
 
 const tar = require('../..')
 const timer = require('../timer.js')()

--- a/benchmarks/extract/node-tar-fmap-sync.js
+++ b/benchmarks/extract/node-tar-fmap-sync.js
@@ -6,7 +6,7 @@ process.on('exit', _ => rimraf.sync(cwd))
 const path = require('path')
 const file = process.argv[2] || path.resolve(__dirname, '../npm.tar')
 const fs = require('fs')
-const { O_CREAT, O_TRUNC, O_WRONLY, UV_FS_O_FILEMAP } = fs.constants
+const { O_CREAT, O_TRUNC, O_WRONLY, UV_FS_O_FILEMAP = 0 } = fs.constants
 
 const tar = require('../..')
 const timer = require('../timer.js')()

--- a/benchmarks/extract/node-tar-fmap-sync.js
+++ b/benchmarks/extract/node-tar-fmap-sync.js
@@ -1,0 +1,19 @@
+const cwd = __dirname + '/cwd'
+const rimraf = require('rimraf')
+rimraf.sync(cwd)
+require('mkdirp').sync(cwd)
+process.on('exit', _ => rimraf.sync(cwd))
+const path = require('path')
+const file = process.argv[2] || path.resolve(__dirname, '../npm.tar')
+const fs = require('fs')
+const { O_CREAT, O_TRUNC, O_WRONLY, UV_FS_O_FILEMAP } = fs.constants
+
+const tar = require('../..')
+const timer = require('../timer.js')()
+tar.x({
+  fflag: (UV_FS_O_FILEMAP | O_TRUNC | O_CREAT | O_WRONLY),
+  file: file,
+  sync: true,
+  cwd: cwd
+})
+timer()

--- a/lib/unpack.js
+++ b/lib/unpack.js
@@ -159,6 +159,7 @@ class Unpack extends Parser {
     this.umask = typeof opt.umask === 'number' ? opt.umask : this.processUmask
     // default mode for dirs created as parents
     this.dmode = opt.dmode || (0o0777 & (~this.umask))
+    this.fflag = opt.fflag || 'w'
     this.fmode = opt.fmode || (0o0666 & (~this.umask))
     this.on('entry', entry => this[ONENTRY](entry))
   }
@@ -294,6 +295,7 @@ class Unpack extends Parser {
   [FILE] (entry) {
     const mode = entry.mode & 0o7777 || this.fmode
     const stream = new fsm.WriteStream(entry.absolute, {
+      flags: this.fflag,
       mode: mode,
       autoClose: false
     })
@@ -515,7 +517,7 @@ class UnpackSync extends Unpack {
     let stream
     let fd
     try {
-      fd = fs.openSync(entry.absolute, 'w', mode)
+      fd = fs.openSync(entry.absolute, this.fflag, mode)
     } catch (er) {
       return oner(er)
     }

--- a/test/unpack.js
+++ b/test/unpack.js
@@ -11,7 +11,7 @@ const makeTar = require('./make-tar.js')
 const Header = require('../lib/header.js')
 const z = require('minizlib')
 const fs = require('fs')
-const { O_CREAT, O_TRUNC, O_WRONLY, UV_FS_O_FILEMAP } = fs.constants
+const { O_CREAT, O_TRUNC, O_WRONLY, UV_FS_O_FILEMAP = 0 } = fs.constants
 const path = require('path')
 const fixtures = path.resolve(__dirname, 'fixtures')
 const files = path.resolve(fixtures, 'files')


### PR DESCRIPTION
This allows the WriteStream flags to be used when writing files to be specified as an option.

This allows programs using node-tar to take advantage of writing files using a file mapping, which can be significantly faster on Windows. Support landed in libuv in https://github.com/libuv/libuv/pull/2295 and in Node.js in https://github.com/nodejs/node/pull/29260.

For the included benchmarks, execution time drops from 6.6s to 2.8s for async and from 15.8s to 3.4s for sync on my local machine. This depends heavily on the machine being used: can range from negligible improvements to even better than the above.