### PR TITLE
New header uncaught exception fix

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -102,7 +102,13 @@ module.exports = warner(class Parser extends EE {
   }
 
   [CONSUMEHEADER] (chunk, position) {
-    const header = new Header(chunk, position, this[EX], this[GEX])
+    let header
+    try {
+      header = new Header(chunk, position, this[EX], this[GEX])
+    } catch (er) {
+      this.abort(er.message, er)
+      return
+    }
 
     if (header.nullBlock)
       this[EMIT]('nullBlock')

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -106,8 +106,7 @@ module.exports = warner(class Parser extends EE {
     try {
       header = new Header(chunk, position, this[EX], this[GEX])
     } catch (er) {
-      this.abort(er.message, er)
-      return
+      return this.abort(er.message, er)
     }
 
     if (header.nullBlock)


### PR DESCRIPTION
When given a bad/corrupted file then in `Parse -> [CONSUMEHEADER] -> new Header(...)`
there is an error thrown (in this case `TypeError: invalid base256 encoding`).
This error does not generate an 'error' event and bubbles all the way up to become an 'UNCAUGHT EXCEPTION', this is not reasonable since an extractor/parser should not kill a service.
I offer a try catch solution around the `new Header(...)` with an abort and return in case of an error, this way instead of killing the service we get an error event.