### PR TITLE
unpack: conditionally use a file mapping to write files

### DIFF
--- a/lib/unpack.js
+++ b/lib/unpack.js
@@ -4,6 +4,7 @@ const assert = require('assert')
 const EE = require('events').EventEmitter
 const Parser = require('./parse.js')
 const fs = require('fs')
+const { O_CREAT, O_TRUNC, O_WRONLY, UV_FS_O_FILEMAP = 0 } = fs.constants
 const fsm = require('fs-minipass')
 const path = require('path')
 const mkdir = require('./mkdir.js')
@@ -78,6 +79,13 @@ const uint32 = (a, b, c) =>
   a === a >>> 0 ? a
   : b === b >>> 0 ? b
   : c
+
+/* istanbul ignore next */
+const fMapEnabled = process.platform === 'win32' && !!UV_FS_O_FILEMAP
+const fMapLimit = 512 * 1024
+const fMapFlag = UV_FS_O_FILEMAP | O_TRUNC | O_CREAT | O_WRONLY
+/* istanbul ignore next */
+const getFlag = size => (fMapEnabled && size < fMapLimit) ? fMapFlag : 'w'
 
 class Unpack extends Parser {
   constructor (opt) {
@@ -294,6 +302,7 @@ class Unpack extends Parser {
   [FILE] (entry) {
     const mode = entry.mode & 0o7777 || this.fmode
     const stream = new fsm.WriteStream(entry.absolute, {
+      flags: getFlag(entry.size),
       mode: mode,
       autoClose: false
     })
@@ -515,7 +524,7 @@ class UnpackSync extends Unpack {
     let stream
     let fd
     try {
-      fd = fs.openSync(entry.absolute, 'w', mode)
+      fd = fs.openSync(entry.absolute, getFlag(entry.size), mode)
     } catch (er) {
       return oner(er)
     }


### PR DESCRIPTION
Use a file mapping to write files up to 512KB.

The limit where using a file mapping stops being an advantage varies from machine to machine. 512KB is a reasonable value to use here, close to the lower bound, to avoid tar becoming slower in some machines.

This is an alternative to https://github.com/npm/node-tar/pull/227 and also makes https://github.com/npm/pacote/pull/8 unnecessary.

cc @isaacs 
