### PR TITLE
Fix invalid fileSize atom in header

### DIFF
--- a/lib/header.js
+++ b/lib/header.js
@@ -270,8 +270,8 @@ const octalString = (number, size) =>
   padOctal(Math.floor(number).toString(8), size)
 
 const padOctal = (string, size) =>
-  (string.length === size - 1 ? string
-  : new Array(size - string.length - 1).join('0') + string + ' ') + '\0'
+  (string.length === size ? string
+  : new Array(size - string.length).join('0') + string) + '\0'
 
 const encDate = (buf, off, size, date) =>
   date === null ? false :


### PR DESCRIPTION
# What / Why
According to the TAR specification, the fileSize header atom should be stored as 11 ascii-encoded octals plus a null terminator.

For some reason a ' ' whitespace is being added by this package, which was creating unusable TAR archives for me (using other libraries to decode).

I'm not sure why this space was added, possibly someone saw the null terminator and assumed that there must be a space at the end.  Either way, removing it makes readable archives.
