### PR TITLE
fix: ensuring close event is emited after stream has ended. 

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -28,6 +28,7 @@ const maxMetaEntrySize = 1024 * 1024
 const Entry = require('./read-entry.js')
 const Pax = require('./pax.js')
 const zlib = require('minizlib')
+const { nextTick } = require('process')
 
 const gzipHeader = Buffer.from([0x1f, 0x8b])
 const STATE = Symbol('state')
@@ -59,6 +60,7 @@ const DONE = Symbol('onDone')
 const SAW_VALID_ENTRY = Symbol('sawValidEntry')
 const SAW_NULL_BLOCK = Symbol('sawNullBlock')
 const SAW_EOF = Symbol('sawEOF')
+const CLOSESTREAM = Symbol('closeStream')
 
 const noop = _ => true
 
@@ -89,7 +91,6 @@ module.exports = warner(class Parser extends EE {
         this.emit('prefinish')
         this.emit('finish')
         this.emit('end')
-        this.emit('close')
       })
     }
 
@@ -114,6 +115,9 @@ module.exports = warner(class Parser extends EE {
     this[ABORTED] = false
     this[SAW_NULL_BLOCK] = false
     this[SAW_EOF] = false
+
+    this.on('end', () => this[CLOSESTREAM]())
+
     if (typeof opt.onwarn === 'function') {
       this.on('warn', opt.onwarn)
     }
@@ -215,6 +219,10 @@ module.exports = warner(class Parser extends EE {
         }
       }
     }
+  }
+
+  [CLOSESTREAM] () {
+    nextTick(() => this.emit('close'))
   }
 
   [PROCESSENTRY] (entry) {

--- a/lib/unpack.js
+++ b/lib/unpack.js
@@ -234,7 +234,6 @@ class Unpack extends Parser {
       this.emit('prefinish')
       this.emit('finish')
       this.emit('end')
-      this.emit('close')
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "events-to-array": "^1.1.2",
     "mutate-fs": "^2.1.1",
     "rimraf": "^3.0.2",
-    "tap": "^16.0.1",
-    "tar-fs": "^2.1.1",
-    "tar-stream": "^2.2.0"
+    "tap": "^16.0.1"
   },
   "license": "ISC",
   "engines": {


### PR DESCRIPTION
For node 18 compatibility

Fixes #321

Node 18 pipelines specifically require the end event to be emitted and handled before the close event is.

I tried a test with a local tar file and it was still passing without the fix, but a remote tar file failed, so just stuck to that.