### PR TITLE
chore: use a local instead of remote file for test

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "end-of-stream": "^1.4.3",
     "events-to-array": "^1.1.2",
     "mutate-fs": "^2.1.1",
+    "nock": "^13.2.9",
     "rimraf": "^3.0.2",
     "tap": "^16.0.1"
   },


### PR DESCRIPTION
I was able to replicate the same behavior from #332 by piping a readable
stream with a `highWaterMark` of 1 to extract. I confirmed this test
still failed without the fixes from #332 and now passes.
